### PR TITLE
壁をすり抜けてしまうバグ解消

### DIFF
--- a/single/js/collider-check.js
+++ b/single/js/collider-check.js
@@ -70,8 +70,8 @@ function movePlayer() {
     // 特定の加速度になったら進む(足踏みで動く程度の加速度)
       if (camera && !isIntersect) {
 
-        position.x -= 0.80 * Math.sin(Math.PI * (rotation.y) / 180);
-        position.z -= 0.80 * Math.cos(Math.PI * (rotation.y) / 180);
+        position.x -= 0.8 * Math.sin(Math.PI * (rotation.y) / 180);
+        position.z -= 0.8 * Math.cos(Math.PI * (rotation.y) / 180);
         camera.setAttribute('position', position);
 
         // 歩数カウントのインクリメント
@@ -83,8 +83,8 @@ function movePlayer() {
         steps2.setAttribute('value', nowSteps);
       } else {
         // 衝突したら跳ね返る
-        position.x += 0.3 * Math.sin(Math.PI * (rotation.y) / 180);
-        position.z += 0.3 * Math.cos(Math.PI * (rotation.y) / 180);
+        position.x += 0.8 * Math.sin(Math.PI * (rotation.y) / 180);
+        position.z += 0.8 * Math.cos(Math.PI * (rotation.y) / 180);
         camera.setAttribute('position', position);
       }
     }

--- a/single/maze.html
+++ b/single/maze.html
@@ -33,7 +33,7 @@
       <!-- カメラ -->
       <!-- class="collidable"が付与されたオブジェクトを対象に、1以内に近づいたら、衝突イベントを発生させる -->
       <!-- 当たり判定用の自作コンポーネントを設定 -->
-      <a-entity id="camera" camera look-controls raycaster="objects: .collidable; far: 1;" collider-check rotation="0 0 0" position="35 2 75">
+      <a-entity id="camera" camera look-controls raycaster="objects: .collidable; far: 1.6;" collider-check rotation="0 0 0" position="35 2 75">
         <!-- タイマー＄歩数表示 -->
         <a-text id="time2" font="mozillavr" value="00:00" color="#BBB" position="-0.8 0.6 -0.6" scale="1 1 1" align="left" baseline="top"></a-text>
         <a-text id="steps2" font="mozillavr"  value="0" color="#BBB" position="0.8 0.6 -0.6" scale="1 1 1" align="right" baseline="top"></a-text>


### PR DESCRIPTION
加速度で進行する処理を入れてから壁をすり抜けるバグが発生していた。
壁の跳ね返りを1歩進む距離と一緒にし、
壁の衝突判定の距離を1.6にした。
まだ、斜めの衝突に弱い気がするが一応すり抜けの軽減になった。